### PR TITLE
docs: distinguish nightly builds from npm CLI

### DIFF
--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -3,23 +3,24 @@
 On Linux and macOS, Backplane can run as a service for your user so you do not need
 to keep a terminal open.
 
+For a command-line host, [build Backplane from source](./install.md#command-line-hosts).
+
 ## Manage the service
 
 Run these commands on the machine that will host Backplane:
 
 | Task                            | Command                                       |
 | ------------------------------- | --------------------------------------------- |
-| Install and start               | `npx @backplane/cli@latest service install`   |
-| Inspect status and log location | `npx @backplane/cli@latest service status`    |
-| Update or repair                | `npx @backplane/cli@latest service update`    |
-| Stop and remove from startup    | `npx @backplane/cli@latest service uninstall` |
+| Install and start               | `node apps/server/dist/bin.mjs service install`   |
+| Inspect status and log location | `node apps/server/dist/bin.mjs service status`    |
+| Update or repair                | `node apps/server/dist/bin.mjs service update`    |
+| Stop and remove from startup    | `node apps/server/dist/bin.mjs service uninstall` |
 
 Uninstalling the service leaves your projects, threads, and settings intact.
 
-Install and update use the version of the CLI you invoke. For nightly, use
-`npx @backplane/cli@nightly service update`; replace `nightly` with an exact version to pin
-one. An older CLI refuses to replace a newer service unless you explicitly add
-`--allow-downgrade`.
+Install and update use the version of the built CLI. Rebuild from the source
+revision you want to run before updating. An older CLI refuses to replace a newer
+service unless you explicitly add `--allow-downgrade`.
 
 Updating restarts the server. Finish active work first, and wait for any remote
 update already in progress. To match a remote client's version, follow

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -57,4 +57,17 @@ user data directory.
 Desktop releases currently support Linux x64. Native Windows and macOS
 installers are not available yet.
 
-For source builds, see the [development instructions](../../README.md#develop).
+## Command-line hosts
+
+Backplane does not currently publish a standalone CLI package to npm. To run a
+command-line host, build from source with Node 24:
+
+```sh
+git clone https://github.com/i2cjak/Backplane.git
+cd Backplane
+vp i
+vp run --filter @backplane/cli build
+node apps/server/dist/bin.mjs serve
+```
+
+For development, see the [development instructions](../../README.md#develop).

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,6 +1,9 @@
 # Install Backplane
 
-Download the Linux x64 AppImage from [Backplane Releases](https://github.com/i2cjak/Backplane/releases).
+Download the current Linux x64 AppImage nightly from
+[Backplane Releases](https://github.com/i2cjak/Backplane/releases). These are
+usable prerelease builds; Backplane does not currently publish a separate stable
+release channel.
 The desktop app includes its Chromium browser, server, Python, the matching Backplane KiCad runtime, and the official KiCad symbols, footprints, 3D models, and project templates.
 You do not need to install Chrome, Node.js, Python, or KiCad separately.
 
@@ -54,13 +57,14 @@ Download the newer AppImage from the same releases page, close Backplane, and
 replace the previous AppImage. Your saved threads and settings remain in your
 user data directory.
 
-Desktop releases currently support Linux x64. Native Windows and macOS
+Nightly desktop releases currently support Linux x64. Native Windows and macOS
 installers are not available yet.
 
 ## Command-line hosts
 
-Backplane does not currently publish a standalone CLI package to npm. To run a
-command-line host, build from source with Node 24:
+The desktop nightly is the normal installation path. Backplane does not
+currently publish a standalone CLI package to npm, so `npx @backplane/cli@latest`
+cannot be used for a command-line host. Build from source with Node 24 instead:
 
 ```sh
 git clone https://github.com/i2cjak/Backplane.git

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -3,6 +3,8 @@
 Connect a phone, browser, or another desktop app to Backplane running on a different
 machine. That machine must stay running and reachable while you work.
 
+For a command-line host, [build Backplane from source](./install.md#command-line-hosts).
+
 ## Backplane Connect
 
 Backplane Connect makes an environment available to your other devices without setting
@@ -12,12 +14,12 @@ Connections**, sign in, and enable **Backplane Connect** for that environment.
 For a command-line host, run:
 
 ```bash
-npx @backplane/cli@latest connect
+node apps/server/dist/bin.mjs connect
 ```
 
 Follow the sign-in instructions. Setup offers a
 [background service](./background-service.md); if you decline it, start the
-server with `npx @backplane/cli serve`. Saving your sign-in alone does not make the machine
+server with `node apps/server/dist/bin.mjs serve`. Saving your sign-in alone does not make the machine
 reachable.
 
 On your other device, sign in to the same Backplane Connect account and choose the
@@ -41,13 +43,13 @@ For a command-line host, replace `<private-ip>` with the host's LAN or tailnet
 address:
 
 ```bash
-npx @backplane/cli serve --host <private-ip>
+node apps/server/dist/bin.mjs serve --host <private-ip>
 ```
 
 If a server is already running, generate a fresh link without restarting it:
 
 ```bash
-npx @backplane/cli pair
+node apps/server/dist/bin.mjs pair
 ```
 
 Scan the QR code on your phone or paste the pairing URL into **Add environment**
@@ -86,13 +88,13 @@ HTTPS** in **Settings → Connections**. Turn it off there to remove that route.
 To start a command-line server with Tailscale HTTPS:
 
 ```bash
-npx @backplane/cli serve --tailscale-serve
+node apps/server/dist/bin.mjs serve --tailscale-serve
 ```
 
 For an already-running server:
 
 ```bash
-npx @backplane/cli pair --tailscale
+node apps/server/dist/bin.mjs pair --tailscale
 ```
 
 The pairing link uses an address such as `https://machine.tailnet.ts.net/`.
@@ -104,7 +106,7 @@ tailscale serve --https=443 off
 ```
 
 If that port is already in use, choose another with
-`--tailscale-serve-port`. See `npx @backplane/cli pair --help` for other pairing options.
+`--tailscale-serve-port`. See `node apps/server/dist/bin.mjs pair --help` for other pairing options.
 
 ### Hosted web app
 
@@ -147,7 +149,7 @@ For Antigravity's Google callback on a remote host, see
 On the host, **Settings → Connections** lets authorized administrators create
 pairing links and revoke client sessions. Revoking an unused link prevents new
 pairings; revoke a device's session to remove its existing access. Command-line
-management is available through `npx @backplane/cli auth --help`.
+management is available through `node apps/server/dist/bin.mjs auth --help`.
 
 A session with an open connection stays listed after its access credential
 expires.

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -34,16 +34,18 @@ The offered action depends on how the server runs:
 For a background service, run the matching version's CLI on the host:
 
 ```sh
-npx @backplane/cli@<client-version> service update
+node apps/server/dist/bin.mjs service update
 ```
 
-Replace `<client-version>` with the version shown in the notice. Using
-`@latest` only resolves the mismatch if your client is on that release. An older
-service launcher may require this local update before it supports remote updates
-and rollback.
+Backplane does not currently publish a standalone CLI package. For a
+command-line host, update the source checkout to the version shown in the
+notice, rebuild it as described in [Command-line hosts](./install.md#command-line-hosts),
+then run the command above. An older service launcher may require this local
+update before it supports remote updates and rollback.
 
-For a foreground server, the copied command is `npx @backplane/cli@<client-version>`. Add
-`serve` if you normally run without a browser, and preserve options such as
+For a foreground source-built server, start the rebuilt executable with
+`node apps/server/dist/bin.mjs`. Add `serve` if you normally run without a
+browser, and preserve options such as
 `--host` or `--tailscale-serve`. See
 [background services](./background-service.md) for service management.
 

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -8,12 +8,15 @@ hosted app for the first time. Existing workspaces skip this flow.
 - **This computer** runs agents on the computer that hosts Backplane. It does not
   require an account.
 - **Backplane Connect** connects computers that are signed in to your account. Run
-  `npx @backplane/cli connect` on each computer you want to add, then start Backplane or run
-  `npx @backplane/cli serve` so the computer stays available.
+  `node apps/server/dist/bin.mjs connect` on each computer you want to add, then start
+  Backplane or run `node apps/server/dist/bin.mjs serve` so the computer stays available.
+  For command-line hosts,
+  [build Backplane from source](./install.md#command-line-hosts) first.
 - **Pair a server** connects directly to a server on your network or tailnet.
-  Start the server with `npx @backplane/cli serve`, then run `npx @backplane/cli pair --tailscale` and
-  paste the pairing link. You can also run `npx @backplane/cli serve --host <address>` and
-  use `npx @backplane/cli pair` when the server is already reachable on your network.
+  Start the server with `node apps/server/dist/bin.mjs serve`, then run
+  `node apps/server/dist/bin.mjs pair --tailscale` and paste the pairing link. You can
+  also run `node apps/server/dist/bin.mjs serve --host <address>` and use
+  `node apps/server/dist/bin.mjs pair` when the server is already reachable on your network.
 
 If Backplane cannot confirm the workspace during startup, the setup flow shows
 **Still connecting** instead of opening the app. Select **Reload** to try again.


### PR DESCRIPTION
Clarifies the two available installation paths: nightly GitHub Release artifacts for desktop/mobile users and source builds for command-line hosts while `@backplane/cli` is unavailable on npm.

Updates the affected command-line, background-service, remote-access, and update examples to use the built server entry point.

Fixes #8