### PR TITLE
Avoid pairing credentials in service logs

### DIFF
--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -10,6 +10,7 @@ import {
   ThreadId,
   TurnId,
 } from "@backplane/contracts";
+import { HostProcessEnvironment } from "@backplane/shared/hostProcess";
 import { resolveProjectAutoPull } from "@backplane/shared/serverSettings";
 import * as Cause from "effect/Cause";
 import * as Console from "effect/Console";
@@ -49,6 +50,7 @@ import {
   formatHostForUrl,
   isWildcardHost,
   issueHeadlessServeAccessInfo,
+  shouldPrintHeadlessPairingDetails,
 } from "./startupAccess.ts";
 
 export class ServerRuntimeStartupError extends Schema.TaggedErrorClass<ServerRuntimeStartupError>()(
@@ -926,11 +928,14 @@ export const make = (options?: StartupOptions) =>
             Effect.ignoreCause({ log: true }),
           );
           if (serverConfig.startupPresentation === "headless") {
-            const accessInfo = yield* issueHeadlessServeAccessInfo();
-            yield* runStartupPhase(
-              "headless.output",
-              Console.log(formatHeadlessServeOutput(accessInfo)),
-            );
+            const environment = yield* HostProcessEnvironment;
+            if (shouldPrintHeadlessPairingDetails(environment)) {
+              const accessInfo = yield* issueHeadlessServeAccessInfo();
+              yield* runStartupPhase(
+                "headless.output",
+                Console.log(formatHeadlessServeOutput(accessInfo)),
+              );
+            }
           } else {
             const startupBrowserTarget = yield* resolveStartupBrowserTarget;
             if (serverConfig.mode !== "desktop") {

--- a/apps/server/src/startupAccess.test.ts
+++ b/apps/server/src/startupAccess.test.ts
@@ -7,6 +7,7 @@ import {
   resolveHeadlessConnectionHost,
   resolveHeadlessConnectionString,
   resolveListeningPort,
+  shouldPrintHeadlessPairingDetails,
 } from "./startupAccess.ts";
 
 it("prefers localhost when no explicit host is configured", () => {
@@ -76,4 +77,11 @@ it("formats headless serve output with the connection string, token, pairing url
   expect(output).toContain("Token: PAIRCODE");
   expect(output).toContain("Pairing URL: http://192.168.1.42:3773/pair#token=PAIRCODE");
   assert.isTrue(output.includes("█") || output.includes("▀") || output.includes("▄"));
+});
+
+it("does not print pairing details for boot services", () => {
+  expect(
+    shouldPrintHeadlessPairingDetails({ BACKPLANE_BOOT_SERVICE_UNIT: "backplane.service" }),
+  ).toBe(false);
+  expect(shouldPrintHeadlessPairingDetails({})).toBe(true);
 });

--- a/apps/server/src/startupAccess.ts
+++ b/apps/server/src/startupAccess.ts
@@ -13,6 +13,9 @@ export interface HeadlessServeAccessInfo {
   readonly pairingUrl: string;
 }
 
+export const shouldPrintHeadlessPairingDetails = (environment: NodeJS.ProcessEnv): boolean =>
+  environment.BACKPLANE_BOOT_SERVICE_UNIT === undefined;
+
 type NetworkInterfacesMap = ReturnType<typeof NodeOS.networkInterfaces>;
 
 export const isLoopbackHost = (host: string | undefined): boolean => {


### PR DESCRIPTION
Service startup no longer writes one-time pairing credentials to persistent service stdout. Interactive `backplane serve` output remains available.

Fixes #6