### PR TITLE
Fix service installation from source builds

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -110,14 +110,22 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
   usePinnedLauncher = false,
   installerPath = macInstallerPath,
+  sourceBuild = false,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const home = yield* fs.makeTempDirectoryScoped({ prefix: "backplane-boot-service-test-" });
   const baseDir = path.join(home, ".backplane");
   const sourceLauncher = path.join(home, "service-launcher.mjs");
+  const sourceRuntime = path.join(home, "apps", "server", "dist", "bin.mjs");
   const statePath = path.join(baseDir, "runtime", "service-state.json");
   yield* fs.writeFileString(sourceLauncher, "export {};\n");
+  yield* fs.makeDirectory(path.dirname(sourceRuntime), { recursive: true });
+  yield* fs.writeFileString(sourceRuntime, "export {};\n");
+  yield* fs.writeFileString(
+    path.join(path.dirname(sourceRuntime), "service-launcher.mjs"),
+    "export {};\n",
+  );
   const runtime = pinnedRuntimePaths(path, baseDir, "1.2.3");
   yield* fs.makeDirectory(path.dirname(runtime.entryPath), { recursive: true });
   yield* fs.writeFileString(runtime.entryPath, "export {};\n");
@@ -190,10 +198,14 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       baseDir,
       logsDir: path.join(baseDir, "userdata", "logs"),
       cliVersion: "1.2.3",
-      host: {
-        execPath: "/usr/bin/node",
-        ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
-      },
+      ...(sourceBuild
+        ? {}
+        : {
+            host: {
+              execPath: "/usr/bin/node",
+              ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
+            },
+          }),
     }).pipe(
       Effect.provideService(ProcessRunner.ProcessRunner, runner),
       Effect.provide(
@@ -201,7 +213,10 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
           Layer.succeed(HostProcessPlatform, platform),
           Layer.succeed(HostProcessUserId, 501),
           Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
-          Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
+          Layer.succeed(HostProcessArguments, [
+            "/usr/bin/node",
+            sourceBuild ? sourceRuntime : path.join(home, "bin.mjs"),
+          ]),
           ConfigProvider.layer(
             ConfigProvider.fromEnv({
               env: { HOME: home, ...(environmentPath === "" ? {} : { PATH: environmentPath }) },
@@ -466,6 +481,23 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(yield* fs.readFileString(plan.launcherPath)).toBe(
         "export const source = 'pinned runtime';\n",
       );
+    }),
+  );
+
+  it.effect("uses a source-built CLI instead of installing its unpublished version", () =>
+    Effect.gen(function* () {
+      const { service, commands, fs, runtime } = yield* makeHarness(
+        "linux",
+        false,
+        macInstallerPath,
+        true,
+      );
+
+      yield* fs.remove(runtime.sentinelPath);
+      yield* service.install();
+
+      expect(commands.some((command) => command.startsWith("npm "))).toBe(false);
+      expect(yield* fs.readLink(runtime.entryPath)).toContain("/apps/server/dist/bin.mjs");
     }),
   );
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -1,4 +1,5 @@
 import {
+  HostProcessArguments,
   HostProcessExecutablePath,
   HostProcessPlatform,
   HostProcessUserId,
@@ -494,6 +495,8 @@ export class BootService extends Context.Service<
 
 export interface BootServiceHost {
   readonly execPath: string;
+  /** Bundled CLI entry from a source checkout. */
+  readonly runtimeSourcePath?: string;
   readonly launcherSourcePath?: string;
 }
 
@@ -504,6 +507,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   readonly host?: BootServiceHost;
 }) {
   const hostExecPath = yield* HostProcessExecutablePath;
+  const processArguments = yield* HostProcessArguments;
   const platform = yield* HostProcessPlatform;
   const uid = yield* HostProcessUserId;
   const homeDir = yield* Config.string("HOME").pipe(Config.withDefault(""));
@@ -511,7 +515,18 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
-  const host = input.host ?? { execPath: hostExecPath };
+  const invocationEntryPath = processArguments[1];
+  const sourceRuntimePath =
+    input.host?.runtimeSourcePath ??
+    (invocationEntryPath !== undefined &&
+    !invocationEntryPath.replaceAll("\\", "/").includes("/node_modules/") &&
+    invocationEntryPath.replaceAll("\\", "/").endsWith("/apps/server/dist/bin.mjs")
+      ? invocationEntryPath
+      : undefined);
+  const host: BootServiceHost = input.host ?? {
+    execPath: hostExecPath,
+    ...(sourceRuntimePath === undefined ? {} : { runtimeSourcePath: sourceRuntimePath }),
+  };
   const xmlSafeInstallerDirectories = installerPath.split(":").filter(
     (directory) =>
       directory.length > 0 &&
@@ -547,7 +562,14 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const runtimePaths = pinnedRuntimePaths(path, input.baseDir, input.cliVersion);
   const launcherSourcePath =
     host.launcherSourcePath ??
-    path.join(path.dirname(runtimePaths.entryPath), SERVICE_LAUNCHER_FILE);
+    path.join(
+      path.dirname(
+        host.runtimeSourcePath ??
+          (input.host === undefined ? invocationEntryPath : undefined) ??
+          runtimePaths.entryPath,
+      ),
+      SERVICE_LAUNCHER_FILE,
+    );
   const writeDurably = (filePath: string, contents: string) =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -708,6 +730,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       fs,
       path,
       runner,
+      ...(host.runtimeSourcePath === undefined ? {} : { sourceEntryPath: host.runtimeSourcePath }),
       validate: (runtime) =>
         runner
           .run({

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -84,6 +84,42 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
     }),
   );
 
+  it.effect("stages a source-built runtime without querying the package registry", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "backplane-pinned-source-" });
+      const sourceDir = yield* fs.makeTempDirectoryScoped({ prefix: "backplane-source-build-" });
+      const sourceEntry = path.join(sourceDir, "dist", "bin.mjs");
+      yield* fs.makeDirectory(path.dirname(sourceEntry), { recursive: true });
+      yield* fs.writeFileString(sourceEntry, "export {};\n");
+      const commands: ProcessRunner.ProcessRunInput[] = [];
+
+      const paths = yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner: ProcessRunner.ProcessRunner.of({
+          run: (input) =>
+            Effect.sync(() => commands.push(input)).pipe(
+              Effect.andThen(Effect.die("must not run")),
+            ),
+        }),
+        sourceEntryPath: sourceEntry,
+        validate: (runtime) =>
+          fs.exists(runtime.entryPath).pipe(
+            Effect.flatMap((exists) => (exists ? Effect.void : Effect.die("missing runtime"))),
+            Effect.orDie,
+          ),
+      });
+
+      assert.deepEqual(commands, []);
+      assert.equal(yield* fs.readLink(paths.entryPath), sourceEntry);
+      assert.equal(yield* fs.readFileString(paths.sentinelPath), "1.2.3\n");
+    }),
+  );
+
   it.effect("does not try a different installer for npm permission failures", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -73,7 +73,9 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedErrorClass<
 
 /**
  * Installs `@backplane/cli@<version>` into the pinned runtime directory unless a complete
- * install is already there, and returns its paths. The sentinel is written
+ * install is already there, and returns its paths. A source-built CLI can
+ * provide its bundled entry instead; the staged symlink keeps that build's
+ * external dependencies resolvable from its checkout. The sentinel is written
  * only after npm exits 0; checking the entry file alone is not enough. npm
  * extracts files before running native builds (node-pty), so a killed
  * install leaves a plausible-looking but broken tree behind.
@@ -84,6 +86,8 @@ interface PinnedRuntimeInstallInput {
   readonly fs: FileSystem.FileSystem;
   readonly path: Path.Path;
   readonly runner: ProcessRunner.ProcessRunner["Service"];
+  /** A bundled CLI entry from a source checkout, used instead of the registry. */
+  readonly sourceEntryPath?: string;
   readonly validate: (
     paths: PinnedRuntimePaths,
   ) => Effect.Effect<void, PinnedRuntimeInstallError | PinnedRuntimePreflightBlockedError>;
@@ -152,48 +156,68 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
   };
 
   return yield* Effect.gen(function* () {
-    const installStep = "installing the pinned backplane runtime (this can take a few minutes)";
-    const installArgs = [
-      "install",
-      "--prefix",
-      stagingDir,
-      "--no-fund",
-      "--no-audit",
-      `@backplane/cli@${input.version}`,
-    ];
-    yield* runner
-      .run({
-        command: "npm",
-        args: installArgs,
-        // Native dependencies may compile from source on slower machines.
-        timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
-      })
-      .pipe(
-        Effect.catchTags({
-          ProcessSpawnError: (error) =>
-            error.cause instanceof PlatformError.PlatformError &&
-            error.cause.reason._tag === "NotFound"
-              ? // pnpm-managed Node installations do not include npm. Keep npm
-                // installation semantics for the pinned runtime and native builds.
-                runner.run({
-                  command: "pnpm",
-                  args: ["--package=npm@11", "dlx", "npm", ...installArgs],
-                  timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
-                })
-              : Effect.fail(error),
-        }),
-        Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
-        Effect.filterOrFail(
-          (result) => result.code === 0,
-          (result) =>
+    if (input.sourceEntryPath !== undefined) {
+      yield* fs.makeDirectory(input.path.dirname(stagingPaths.entryPath), { recursive: true }).pipe(
+        Effect.mapError(
+          (cause) =>
             new PinnedRuntimeInstallError({
-              step: installStep,
-              exitCode: Number(result.code),
-              stdoutLength: result.stdout.length,
-              stderrLength: result.stderr.length,
+              step: "staging the local backplane runtime",
+              cause,
             }),
         ),
       );
+      yield* fs
+        .symlink(input.sourceEntryPath, stagingPaths.entryPath)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new PinnedRuntimeInstallError({ step: "staging the local backplane runtime", cause }),
+          ),
+        );
+    } else {
+      const installStep = "installing the pinned backplane runtime (this can take a few minutes)";
+      const installArgs = [
+        "install",
+        "--prefix",
+        stagingDir,
+        "--no-fund",
+        "--no-audit",
+        `@backplane/cli@${input.version}`,
+      ];
+      yield* runner
+        .run({
+          command: "npm",
+          args: installArgs,
+          // Native dependencies may compile from source on slower machines.
+          timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
+        })
+        .pipe(
+          Effect.catchTags({
+            ProcessSpawnError: (error) =>
+              error.cause instanceof PlatformError.PlatformError &&
+              error.cause.reason._tag === "NotFound"
+                ? // pnpm-managed Node installations do not include npm. Keep npm
+                  // installation semantics for the pinned runtime and native builds.
+                  runner.run({
+                    command: "pnpm",
+                    args: ["--package=npm@11", "dlx", "npm", ...installArgs],
+                    timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
+                  })
+                : Effect.fail(error),
+          }),
+          Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
+          Effect.filterOrFail(
+            (result) => result.code === 0,
+            (result) =>
+              new PinnedRuntimeInstallError({
+                step: installStep,
+                exitCode: Number(result.code),
+                stdoutLength: result.stdout.length,
+                stderrLength: result.stderr.length,
+              }),
+          ),
+        );
+    }
 
     yield* input.validate(stagingPaths);
     yield* fs


### PR DESCRIPTION
Fixes #9

Use the bundled CLI and launcher from a source build when installing the background service, so setup does not depend on a matching package being published. Package-based installs continue to stage their exact runtime from the registry.

Tests: focused service runtime and boot-service tests; CLI typecheck.