### PR TITLE
fix(cli): reject builds without web client

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -27,6 +27,7 @@ import {
   ServerCliDevelopmentIconTargetMissingError,
   ServerCliPublishIconSourceMissingError,
   ServerCliPublishIconTargetMissingError,
+  ServerCliWebBuildMissingError,
 } from "./cliErrors.ts";
 
 interface PackageJson {
@@ -170,7 +171,7 @@ const buildCmd = Command.make(
         yield* applyDevelopmentIconOverrides(repoRoot, serverDir);
         yield* Effect.log("[cli] Bundled web app into dist/client");
       } else {
-        yield* Effect.logWarning("[cli] Web dist not found — skipping client bundle.");
+        return yield* new ServerCliWebBuildMissingError({ webDistPath: webDist });
       }
     }),
 ).pipe(Command.withDescription("Build the server package (tsdown + bundle web client)."));

--- a/apps/server/scripts/cliErrors.ts
+++ b/apps/server/scripts/cliErrors.ts
@@ -58,6 +58,17 @@ export class ServerCliDevelopmentIconTargetMissingError extends Schema.TaggedErr
   }
 }
 
+export class ServerCliWebBuildMissingError extends Schema.TaggedErrorClass<ServerCliWebBuildMissingError>()(
+  "ServerCliWebBuildMissingError",
+  {
+    webDistPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing web client build output: ${this.webDistPath}. Build @backplane/web before the CLI.`;
+  }
+}
+
 export class ServerCliBuildAssetMissingError extends Schema.TaggedErrorClass<ServerCliBuildAssetMissingError>()(
   "ServerCliBuildAssetMissingError",
   {


### PR DESCRIPTION
Fix CLI builds that would otherwise package no web client. The CLI build now fails clearly when the web output is unavailable, preventing a server that returns HTTP 503 at the root route.

Fixes #7